### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='osmviz',
+    version='1.0',
+    long_description=open('README', 'r').read(),
+    packages= find_packages('src'),
+    package_dir = {'': 'src'},
+    zip_safe=False,
+    requires = (
+       'PyGame',
+       'PIL',
+    )
+)


### PR DESCRIPTION
This setup allows osmviz to be installed with pip, for example with this in requirements.txt:

```
-e git://github.com/olibook/osmviz.git#egg=osmviz
```

You can do:

```
pip install -r requirements.txt
```

And it'll install directly from Github. You can then import as normal:

```
try:
    from osmviz.manager import PILImageManager, OSMManager
except ImportError, e:
    sys.exit("ImportError: %s.\n"
              "OSM Viz module needed, available from\n"
              "http://cbick.github.com/osmviz/\n\n" % str(e))

```
